### PR TITLE
Possible typo about diameter? (Update lecture_sgMore.tex)

### DIFF
--- a/lecture_sgMore.tex
+++ b/lecture_sgMore.tex
@@ -495,7 +495,7 @@ which implies our desired statement.
 \end{proof}
 
 \paragraph{$\lambda_2$ in a tree.}
-Since a complete binary tree $T_d$ has diameter $2d \leq 2\log_2(n)$,
+Since a complete binary tree $T_d$ has diameter $d \leq 2\log_2(n)$,
 by Lemma~\ref{lem:lambda2diam}, $\lambda_2(\LL_{T_d}) \geq
 \frac{1}{2n\log_2(n)}$.
 


### PR DESCRIPTION
I believe there was a typo about the diameter of a complete tree. I might be wrong