### PR TITLE
possible typo in lagrance lecture

### DIFF
--- a/lecture_lagrange.tex
+++ b/lecture_lagrange.tex
@@ -353,7 +353,7 @@ Now, we can state a more general version of Slater's condition.
 \begin{definition}[Slater's condition] \label{def:slatergeneral}
 A (primal) problem as defined in \eqref{eq:primalprob} fulfills
 Slater's condition if there exists a \emph{strictly feasible} point
-$\yy \in \operatorname{relint}(S)$.
+$\yytil \in \operatorname{relint}(S)$.
 We require $\AA\yytil = \bb$ and $\cc(\yytil) <
 \veczero$.
 This means that the strictly feasible point $\yytil$ lies strictly inside the set $\{\yy : \cc(\yy) \leq \veczero\}$ defined by the inequality constraints.


### PR DESCRIPTION
I think it makes more sense to replace y by \tilde y in this context