### PR TITLE
Fix small error in proof of Cholesky decomposition of graph Laplacians

### DIFF
--- a/lecture_gaussianElim.tex
+++ b/lecture_gaussianElim.tex
@@ -427,7 +427,7 @@ $i,j \in U$.
   And $\LL^{(i)}(U, U)$ is a graph Laplacian of a connected graph on
   the vertex set $U$.
 \end{claim}
-From this claim, it follows that $\LL^{(i-1)}(i,i) \neq 0$ for $i<n-1$,
+From this claim, it follows that $\LL^{(i-1)}(i,i) \neq 0$ for $i<n$,
 since a connected graph Laplacian on a graph with $\abs{U} > 1$
 vertices cannot have a zero on the diagonal, and it follows that
 $\LL^{(n-1)}(i,i) = 0$, because the only graph we allow on one vertex


### PR DESCRIPTION
The claim implies that $L^{(i-1)}(i,i) \neq 0$ implies for all $i < n$ (not just $i < n-1$, so also for $i = n - 1$).